### PR TITLE
(SIMP-1003) Change default provider for rsync service

### DIFF
--- a/build/pupmod-rsync.spec
+++ b/build/pupmod-rsync.spec
@@ -1,7 +1,7 @@
 Summary: Rsync Puppet Module
 Name: pupmod-rsync
 Version: 4.2.0
-Release: 5
+Release: 6
 License: Apache License, Version 2.0
 Group: Applications/System
 Source: %{name}-%{version}-%{release}.tar.gz
@@ -61,6 +61,9 @@ fi
 # Post uninstall stuff
 
 %changelog
+* Wed Apr 13 2016 Kendall Moore <kendall.moore@onyxpoint.com> - 4.2.0-6
+- Changed the default provider for the rsync service to be redhat
+
 * Thu Feb 25 2016 Ralph Wright <ralph.wright@onyxpoint.com> - 4.2.0-5
 - Added compliance function support
 

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -89,6 +89,7 @@ class rsync::server (
       File['/etc/rsyncd.conf'],
       File['/etc/init.d/rsync']
     ],
+    provider   => 'redhat',
     subscribe  => $_subscribe
   }
 


### PR DESCRIPTION
The default provider does not work in RHEL or CentOS service and cannot
enable the rsync service.  Switch to use 'redhat' instead.

SIMP-1001 #comment Fixes the pupmod-simp-rsync part of this story
SIMP-1003 #close