### PR TITLE
[SIMP-1320] rsync service won't start 1st run on systemd

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -84,6 +84,9 @@ class rsync::server (
     enable     => true,
     hasstatus  => true,
     hasrestart => true,
+    start      => '/etc/init.d/rsync start',
+    stop       => '/etc/init.d/rsync stop',
+    status     => '/etc/init.d/rsync status',
     require    => [
       Package['rsync'],
       File['/etc/rsyncd.conf'],


### PR DESCRIPTION
Since SIMP is deploying the custom service file, it's safe to assume the location for start/stop/status.

Details in https://simp-project.atlassian.net/browse/SIMP-1320