### PR TITLE
(SIMP-1450) Update to use new 'simpcat'

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Fri Sep 30 2016 Trevor Vaughan <tvaughan@onyxpoint.com> - 5.0.0-0
+- Updated to use the version of 'simpcat' that does not conflict with
+  'puppetlabs/concat'.
+
 * Thu Jul 07 2016 Nicholas Hughes <nicholasmhughes@gmail.com> - 4.2.2-0
 - Updated the client_nets parameters to pull from global prior to using Hiera
   and to fall back to the safety of 127.0.0.1.

--- a/build/rpm_metadata/requires
+++ b/build/rpm_metadata/requires
@@ -1,5 +1,5 @@
 Requires: pupmod-simp-compliance_markup
 Requires: pupmod-simp-rsyslog >= 5.0.0
-Requires: pupmod-simp-simpcat >= 4.0.0-0
+Requires: pupmod-simp-simpcat >= 6.0.0-0
 Requires: pupmod-simp-stunnel >= 4.2.0-0
 Obsoletes: pupmod-rsync-test >= 0.0.1

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -54,7 +54,7 @@ class rsync::server (
     }
   }
 
-  concat_build { 'rsync':
+  simpcat_build { 'rsync':
     order   => ['global', '*.section'],
     target  => '/etc/rsyncd.conf',
     require => Package['rsync']
@@ -66,7 +66,7 @@ class rsync::server (
     group     => 'root',
     mode      => '0400',
     audit     => 'content',
-    subscribe => Concat_build['rsync'],
+    subscribe => Simpcat_build['rsync'],
     require   => Package['rsync'],
     notify    => Service['rsync']
   }

--- a/manifests/server/global.pp
+++ b/manifests/server/global.pp
@@ -33,7 +33,7 @@ class rsync::server::global (
 
   include '::tcpwrappers'
 
-  concat_fragment { 'rsync+global':
+  simpcat_fragment { 'rsync+global':
     content => template('rsync/rsyncd.conf.global.erb')
   }
 

--- a/manifests/server/section.pp
+++ b/manifests/server/section.pp
@@ -74,7 +74,7 @@ define rsync::server::section (
 
   include '::rsync::server'
 
-  concat_fragment { "rsync+${name}.section":
+  simpcat_fragment { "rsync+${name}.section":
     content => template('rsync/rsyncd.conf.section.erb')
   }
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name":    "simp-rsync",
-  "version": "4.2.2",
+  "version": "5.0.0",
   "author":  "simp",
   "summary": "manage and rsync server, secured by stunnel",
   "license": "Apache-2.0",
@@ -19,7 +19,7 @@
     },
     {
       "name": "simp/simpcat",
-      "version_requirement": ">= 4.0.0"
+      "version_requirement": ">= 6.0.0"
     },
     {
       "name": "simp/compliance_markup",

--- a/spec/classes/server/global_spec.rb
+++ b/spec/classes/server/global_spec.rb
@@ -7,7 +7,7 @@ describe 'rsync::server::global' do
 
       context "on #{os}" do
         it { is_expected.to compile.with_all_deps }
-        it { is_expected.to create_concat_fragment('rsync+global').with_content(/address = 127.0.0.1/) }
+        it { is_expected.to create_simpcat_fragment('rsync+global').with_content(/address = 127.0.0.1/) }
         it { is_expected.to create_tcpwrappers__allow('rsync') }
       end
     end

--- a/spec/classes/server_spec.rb
+++ b/spec/classes/server_spec.rb
@@ -10,8 +10,8 @@ describe 'rsync::server' do
 
         it { is_expected.to create_class('rsync') }
         it { is_expected.to create_class('stunnel') }
-        it { is_expected.to create_concat_build('rsync').with_target('/etc/rsyncd.conf') }
-        it { is_expected.to create_file('/etc/rsyncd.conf').that_subscribes_to('Concat_build[rsync]') }
+        it { is_expected.to create_simpcat_build('rsync').with_target('/etc/rsyncd.conf') }
+        it { is_expected.to create_file('/etc/rsyncd.conf').that_subscribes_to('Simpcat_build[rsync]') }
         it { is_expected.to create_file('/etc/init.d/rsync').with_source('puppet:///modules/rsync/rsync.init') }
         it { is_expected.to create_service('rsync').that_subscribes_to('Service[stunnel]') }
 
@@ -19,8 +19,8 @@ describe 'rsync::server' do
           let(:params){{ :use_stunnel => false }}
 
           it { is_expected.to compile.with_all_deps }
-          it { is_expected.to create_concat_build('rsync').with_target('/etc/rsyncd.conf') }
-          it { is_expected.to create_file('/etc/rsyncd.conf').that_subscribes_to('Concat_build[rsync]') }
+          it { is_expected.to create_simpcat_build('rsync').with_target('/etc/rsyncd.conf') }
+          it { is_expected.to create_file('/etc/rsyncd.conf').that_subscribes_to('Simpcat_build[rsync]') }
           it { is_expected.to create_file('/etc/init.d/rsync').with_source('puppet:///modules/rsync/rsync.init') }
           it { is_expected.to create_service('rsync') }
           it { is_expected.to create_service('rsync').without_subscribes }


### PR DESCRIPTION
Updated to use the version of 'simpcat' that does not conflict with
'puppetlabs/concat'.

SIMP-1450 #comment Update to use deconflicted 'simpcat'
SIMP-843 #comment Deconflicted 'rsync'
