### PR TITLE
(SIMP-1595) Provide complete dependency boundaries

### DIFF
--- a/build/rpm_metadata/requires
+++ b/build/rpm_metadata/requires
@@ -1,5 +1,9 @@
-Requires: pupmod-simp-compliance_markup
-Requires: pupmod-simp-rsyslog >= 5.0.0
-Requires: pupmod-simp-simpcat >= 4.0.0-0
-Requires: pupmod-simp-stunnel >= 4.2.0-0
 Obsoletes: pupmod-rsync-test >= 0.0.1
+Requires: pupmod-simp-compliance_markup < 2.0.0-0
+Requires: pupmod-simp-compliance_markup >= 1.0.1-0
+Requires: pupmod-simp-rsyslog < 6.0.0-0
+Requires: pupmod-simp-rsyslog >= 5.1.0-0
+Requires: pupmod-simp-simpcat < 6.0.0-0
+Requires: pupmod-simp-simpcat >= 5.0.1-0
+Requires: pupmod-simp-stunnel < 5.0.0-0
+Requires: pupmod-simp-stunnel >= 4.2.8-0

--- a/metadata.json
+++ b/metadata.json
@@ -1,29 +1,33 @@
 {
-  "name":    "simp-rsync",
-  "version": "4.2.2",
-  "author":  "simp",
+  "name": "simp-rsync",
+  "version": "4.2.3",
+  "author": "simp",
   "summary": "manage and rsync server, secured by stunnel",
   "license": "Apache-2.0",
-  "source":  "https://github.com/simp/pupmod-simp-rsync",
+  "source": "https://github.com/simp/pupmod-simp-rsync",
   "project_page": "https://github.com/simp/pupmod-simp-rsync",
-  "issues_url":   "https://simp-project.atlassian.net",
-  "tags": [ "simp", "rsync", "stunnel" ],
+  "issues_url": "https://simp-project.atlassian.net",
+  "tags": [
+    "simp",
+    "rsync",
+    "stunnel"
+  ],
   "dependencies": [
     {
       "name": "simp/rsyslog",
-      "version_requirement": ">= 5.0.0"
+      "version_requirement": ">= 5.1.0 < 6.0.0"
     },
     {
       "name": "simp/stunnel",
-      "version_requirement": ">= 4.2.0"
+      "version_requirement": ">= 4.2.8 < 5.0.0"
     },
     {
       "name": "simp/simpcat",
-      "version_requirement": ">= 4.0.0"
+      "version_requirement": ">= 5.0.1 < 6.0.0"
     },
     {
       "name": "simp/compliance_markup",
-      "version_requirement": ">= 1.0.0"
+      "version_requirement": ">= 1.0.1 < 2.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
Before this patch, dependencies in `metadata.json` and
`build/rpm_metadata/requires` were missing upper boundaries and often
listed inaccurate lower boundaries.  This created an extremely fragile
5.2.X/4.3.X module ecosystem on the Forge, as a major release in any
dependency would be certain to break the module.

This commit resolves the issue by introducing upper and lower boundaries
for each dependency in `metadata.json` and propagates those dependencies
to the RPM dependencies listed in `build/rpm_metadata/requires`.

The minimum version boundaries were determined from the modules as they
were checked out in `simp-core` for the latest SIMP 5.2.X/4.3.X release
(with the addition recent z-version bumps from Forge-readiness patches).

SIMP-1595 #comment Fixed `pupmod-simp-rsync`
SIMP-1639 #close