### PR TITLE
(SIMP-2587) Deconflict stunnel connection name

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Mon Feb 06 2017 Nick Markowski <nmarkowski@keywcorp.com> - 6.0.0-0
+- Renamed the stunnel connection from 'rsync' to 'rsync_server' to
+  deconflict it with the other end of the connection.
+
 * Sun Jan 22 2017 Trevor Vaughan <tvaughan@onyxpoint.com> - 6.0.0-0
 - Switched to using puppetlabs/concat
 - Fixed the startup script for EL6

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -46,7 +46,8 @@ class rsync::server (
   if $stunnel {
     include '::stunnel'
 
-    stunnel::connection { 'rsync':
+    # See simp/init.pp for the other end of this connection.
+    stunnel::connection { 'rsync_server':
       connect      => [873],
       accept       => "${listen_address}:${stunnel_port}",
       client       => false,


### PR DESCRIPTION
- Renamed the stunnel connection from 'rsync' to 'rsync_server' to
  deconflict it with the other end of the connection.

SIMP-2587 #close