### PR TITLE
(SIMP-2675) rsync 'Unknown failure' problem

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Fri Feb 10 2017 Liz Nemsick <lnemsick.simp@gmail.com> - 6.0.0-0
+- Fixed minor bug in rsync provider that caused  'Unknown failure
+  using insync_values?' Puppet message to be generated.
+
 * Sun Jan 22 2017 Trevor Vaughan <tvaughan@onyxpoint.com> - 6.0.0-0
 - Switched to using puppetlabs/concat
 - Fixed the startup script for EL6

--- a/lib/puppet/provider/rsync/rsync.rb
+++ b/lib/puppet/provider/rsync/rsync.rb
@@ -10,9 +10,6 @@ Puppet::Type.type(:rsync).provide(:rsync) do
 
   def initialize(*args)
     super(*args)
-
-    # This will be used to temporarily house the password file
-    @passfile = Tempfile.new('.rsync_provider')
   end
 
   def action
@@ -25,6 +22,9 @@ Puppet::Type.type(:rsync).provide(:rsync) do
   # We've chosen to sync here because of the potential overhead involved with a
   # double rsync run.
   def action_insync?
+    # This will be used to temporarily house the password file
+    @passfile = Tempfile.new('.rsync_provider')
+
     cmd = build_command.join(' ')
     debug %(Executing command #{cmd} with password #{get_password})
     output = Puppet::Util::Execution.execute(cmd, :failonfail => false, :combine => true)


### PR DESCRIPTION
Fix bug whereby 'Unknown failure using insync_values?'
message is emitted by Puppet when files are rsync'd.
NOTE:  Acceptance test does not run because of puppet 4.9.0 bugs.  However, this fix was
tested on a SIMP6 CentOS7 VM.

SIMP-2675 #close