### PR TITLE
(SIMP-2677) Wire down rsync's beaker acceptance tests

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -61,7 +61,7 @@ acceptance-test-puppet-agent-4.7.1:
     - export PUPPET_INSTALL_VERSION=1.7.2
     - bundle install --no-binstubs --path=vendor
     - bundle exec rake acceptance
-acceptance-test-puppet-agent-4.9.2:
+acceptance-test-puppet-agent-4.9.3:
   stage: test
   cache:
     paths:
@@ -71,6 +71,6 @@ acceptance-test-puppet-agent-4.9.2:
     - beaker
   script:
     - export PUPPET_INSTALL_TYPE=agent
-    - export PUPPET_INSTALL_VERSION=1.9.1
+    - export PUPPET_INSTALL_VERSION=1.9.2
     - bundle install --no-binstubs --path=vendor
     - bundle exec rake acceptance

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,76 @@
+#
+---
+puppet-syntax:
+  stage: test
+  tags:
+    - docker
+  image: ruby:2.1
+  script:
+    - bundle install
+    - bundle exec rake syntax
+puppet-lint:
+  stage: test
+  tags:
+    - docker
+  image: ruby:2.1
+  script:
+    - bundle install
+    - bundle exec rake lint
+puppet-metadata:
+  stage: test
+  tags:
+    - docker
+  image: ruby:2.1
+  script:
+    - bundle install
+    - bundle exec rake metadata
+unit-test-ruby-2.1:
+  stage: test
+  tags:
+    - docker
+  image: ruby:2.1
+  script:
+    - bundle install
+    - bundle exec rake spec
+unit-test-ruby-2.2:
+  stage: test
+  tags:
+    - docker
+  image: ruby:2.2
+  allow_failure: true
+  script:
+    - bundle install
+    - bundle exec rake spec
+unit-test-ruby-2.3:
+  stage: test
+  tags:
+    - docker
+  image: ruby:2.3
+  script:
+    - bundle install
+    - bundle exec rake spec
+acceptance-test-puppet-agent-4.7.1:
+  stage: test
+  cache:
+    paths:
+      - vendor
+  tags:
+    - beaker
+  script:
+    - export PUPPET_INSTALL_TYPE=agent
+    - export PUPPET_INSTALL_VERSION=1.7.2
+    - bundle install --no-binstubs --path=vendor
+    - bundle exec rake acceptance
+acceptance-test-puppet-agent-4.9.2:
+  stage: test
+  cache:
+    paths:
+      - vendor
+  allow_failure: true
+  tags:
+    - beaker
+  script:
+    - export PUPPET_INSTALL_TYPE=agent
+    - export PUPPET_INSTALL_VERSION=1.9.1
+    - bundle install --no-binstubs --path=vendor
+    - bundle exec rake acceptance

--- a/Gemfile
+++ b/Gemfile
@@ -28,7 +28,7 @@ group :development do
   gem 'guard-rake'
   gem 'pry'
   gem 'pry-doc'
-
+  gem 'pry-byebug'
   # `listen` is a dependency of `guard`
   # from `listen` 3.1+, `ruby_dep` requires Ruby version >= 2.2.3, ~> 2.2
   gem 'listen', '~> 3.0.6'
@@ -36,7 +36,10 @@ end
 
 group :system_tests do
   # This patch is required to fix Beaker's broken `aio` handling
-  gem 'beaker', :git => 'https://github.com/trevor-vaughan/beaker.git', :branch => 'BKR-931-2.51.0'
+#  gem 'beaker', :git => 'https://github.com/trevor-vaughan/beaker.git', :branch => 'BKR-931-2.51.0'
+  gem 'beaker'
   gem 'beaker-rspec'
+
+  gem 'beaker-puppet_install_helper',                                            :require => false
   gem 'simp-beaker-helpers', ENV.fetch('SIMP_BEAKER_HELPERS_VERSION', '~> 1.5')
 end

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -1,20 +1,17 @@
 require 'beaker-rspec'
+require 'beaker/puppet_install_helper'
 require 'tmpdir'
 require 'yaml'
 require 'simp/beaker_helpers'
 include Simp::BeakerHelpers
 
 unless ENV['BEAKER_provision'] == 'no'
-  hosts.each do |host|
-    # Install Puppet
-    if host.is_pe?
-      install_pe
-    else
-      install_puppet
-    end
+  if ENV['PUPPET_INSTALL_VERSION'] == nil
+    run_puppet_install_helper('agent', '1.7.1')
+  else
+    run_puppet_install_helper
   end
 end
-
 
 RSpec.configure do |c|
   # ensure that environment OS is ready on each host


### PR DESCRIPTION
There is a bug in upstream puppet 4.9.x (PUP-7214)
that breaks rpm uninstallation.

This patch wires rsync to puppet agent 4.7.x (the LTS release)
until upstream is fixed.