### PR TITLE
(SIMP-2953) Do not show diff on rsync passwd files

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Wed Mar 29 2017 Trevor Vaughan <tvaughan@onyxpoint.com> - 6.0.2-0
+- Ensure that rsync password files are not echoed to the Puppet log
+
 * Thu Mar 17 2017 Liz Nemsick <lnemsick.simp@gmail.com> - 6.0.1-0
 - Remove OBE 'pe' requirement from metadata.json
 - Update puppet version in .travis.yaml

--- a/manifests/server/section.pp
+++ b/manifests/server/section.pp
@@ -129,12 +129,13 @@ define rsync::server::section (
 
   if !empty($auth_users) {
     file { "/etc/rsync/${name}.rsyncd.secrets":
-      ensure  => 'file',
-      owner   => $uid,
-      group   => $gid,
-      mode    => '0600',
-      content => template('rsync/secrets.erb'),
-      require => File['/etc/rsync']
+      ensure    => 'file',
+      owner     => $uid,
+      group     => $gid,
+      mode      => '0600',
+      content   => template('rsync/secrets.erb'),
+      show_diff => false,
+      require   => File['/etc/rsync']
     }
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-rsync",
-  "version": "6.0.1",
+  "version": "6.0.2",
   "author": "SIMP Team",
   "summary": "manage and rsync server, secured by stunnel",
   "license": "Apache-2.0",


### PR DESCRIPTION
Set show_diff to false when managing the rsync password files

SIMP-2953 #close