### PR TITLE
(SIMP-3613) rsync: Update to concat 3.0.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Fri Aug 18 2017 Liz Nemsick <lnemsick.simp@gmail.com> - 6.0.4-0
+- Update concat version in metadata.json & build/rpm_metadata/requires
+
 * Thu Jul 06 2017 Liz Nemsick <lnemsick.simp@gmail.com> - 6.0.3-0
 - Update puppet dependency in metadata.json
 

--- a/build/rpm_metadata/requires
+++ b/build/rpm_metadata/requires
@@ -1,5 +1,5 @@
 Obsoletes: pupmod-rsync-test >= 0.0.1
-Requires: pupmod-puppetlabs-concat < 3.0.0-0
+Requires: pupmod-puppetlabs-concat < 4.0.0-0
 Requires: pupmod-puppetlabs-concat >= 2.2.0-0
 Requires: pupmod-puppetlabs-stdlib < 5.0.0-0
 Requires: pupmod-puppetlabs-stdlib >= 4.13.1-0

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-rsync",
-  "version": "6.0.3",
+  "version": "6.0.4",
   "author": "SIMP Team",
   "summary": "manage and rsync server, secured by stunnel",
   "license": "Apache-2.0",
@@ -15,7 +15,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/concat",
-      "version_requirement": ">= 2.2.0 < 3.0.0"
+      "version_requirement": ">= 2.2.0 < 4.0.0"
     },
     {
       "name": "puppetlabs/stdlib",


### PR DESCRIPTION
concat 3.0.0 is fully backward compatible with 2.x.