### PR TITLE
(SIMP-4892) Fix rsync ordering

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Tue May 08 2018 Adam Yohrling <adam.yohrling@onyxpoint.com> - 6.0.6-0
+- Add `order => 'numeric'` setting to concat for rsyncd.conf
+
 * Mon Feb 12 2018 Liz Nemsick <lnemsick.simp@gmail.com> - 6.0.5-0
 - Update upperbound on puppetlabs/concat version to < 5.0.0
 

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -58,6 +58,7 @@ class rsync::server (
     owner          => 'root',
     group          => 'root',
     mode           => '0400',
+    order          => 'numeric',
     ensure_newline => true,
     warn           => true,
     require        => Package['rsync']

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-rsync",
-  "version": "6.0.5",
+  "version": "6.0.6",
   "author": "SIMP Team",
   "summary": "manage and rsync server, secured by stunnel",
   "license": "Apache-2.0",


### PR DESCRIPTION
The puppetlabs-concat module defaults to using alphanumeric ordering,
which causes the single-digit `5_rsync_global` to come after double-digit
standard sections like `10_rsync_server`. This was causing rsyncd to
complain about the ordering in the config file and only utilizing standard
options (port, etc.) even if set differently.

Refs: SIMP-4892