### PR TITLE
(SIMP-6110) Use (namespaced) simplib::passgen

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,7 @@ addons:
 
 before_install:
   - rm -f Gemfile.lock
+  - gem install -v '~> 1.17' bundler
 
 global:
   - STRICT_VARIABLES=yes

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,9 @@
+* Tue Feb 12 2019 Liz Nemsick <lnemsick.simp@gmail.com> - 6.1.1-0
+- Fixed a template bug that prevented catalogue compilation when
+  rsync::server::section::user_pass was set
+- Use simplib::passgen() in lieu of passgen(), a deprecated simplib
+  Puppet 3 function.
+
 * Thu Oct 11 2018 Nick Miller <nick.miller@onyxpoint.com> - 6.1.0-0
 - Added $package_ensure parameter
   - Changed the package from 'latest' to 'installed'

--- a/lib/puppet/type/rsync.rb
+++ b/lib/puppet/type/rsync.rb
@@ -43,7 +43,7 @@ Puppet::Type.newtype(:rsync) do
     desc <<-EOM
       The password to use. Only used if a username is specified
       If you want the password to be auto-generated, you can use the
-      SIMP 'passgen' function.
+      SIMP 'simplib::passgen' function.
 
         $user = 'foo'
 
@@ -52,7 +52,7 @@ Puppet::Type.newtype(:rsync) do
           target   => '/tmp/foo',
           server   => 'puppet',
           user     => $user,
-          password => passgen($user)
+          password => simplib::passgen($user)
         }
      EOM
   end
@@ -61,7 +61,7 @@ Puppet::Type.newtype(:rsync) do
     desc <<-EOM
       The password to use. Only used if a username is specified
       If you want the password to be auto-generated, you can use the
-      SIMP 'passgen' function.
+      SIMP 'simplib::passgen' function.
 
         $user = 'foo'
 
@@ -70,7 +70,7 @@ Puppet::Type.newtype(:rsync) do
           target   => '/tmp/foo',
           server   => 'puppet',
           user     => $user,
-          password => passgen($user)
+          password => simplib::passgen($user)
         }
      EOM
   end

--- a/manifests/retrieve.pp
+++ b/manifests/retrieve.pp
@@ -67,8 +67,8 @@
 # @param pass
 #   The password to use when connecting to the server
 #
-#   * If left blank, and a username is provided, the ``passgen()`` function
-#     will be used to look up the password
+#   * If left blank, and a username is provided, the ``simplib::passgen()``
+#     function will be used to look up the password
 #
 # @param pull
 #   Pull files from the remote server
@@ -122,7 +122,7 @@ define rsync::retrieve (
   }
   else {
     if $user {
-      $_pass = passgen($user)
+      $_pass = simplib::passgen($user)
     }
     else {
       $_pass = undef

--- a/manifests/server/section.pp
+++ b/manifests/server/section.pp
@@ -11,15 +11,16 @@
 # @param auth_users
 #   A list of usernames that are allowed to connect to this section
 #
-#   * ``passgen()`` will be used to generated random passwords for these users
-#     if they do not already exist in the system
+#   * ``simplib::passgen()`` will be used to generated random passwords for
+#     these users, if they do not already exist in the system
+#   * Ignored if ``user_pass`` is set.
 #
 # @param user_pass
 #   An optional array of ``username:password`` combinations to be added to the
 #   secrets file
 #
-#   * It is recommended that you do not set this and instead let the
-#     ``passgen()`` function generate your passwords
+#   * Not recommended.  Instead, use ``auth_users`` to let the
+#     ``simplib::passgen()`` function generate your passwords
 #   * Entries in this Array should be of the following form:
 #     ``username:password``
 #
@@ -127,7 +128,7 @@ define rsync::server::section (
     content => template('rsync/rsyncd.conf.section.erb')
   }
 
-  if !empty($auth_users) {
+  if !empty($auth_users) or !empty($user_pass) {
     file { "/etc/rsync/${name}.rsyncd.secrets":
       ensure    => 'file',
       owner     => $uid,

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-rsync",
-  "version": "6.1.0",
+  "version": "6.1.1",
   "author": "SIMP Team",
   "summary": "manage and rsync server, secured by stunnel",
   "license": "Apache-2.0",
@@ -27,7 +27,7 @@
     },
     {
       "name": "simp/simplib",
-      "version_requirement": ">= 3.1.0 < 4.0.0"
+      "version_requirement": ">= 3.5.0 < 4.0.0"
     },
     {
       "name": "simp/stunnel",

--- a/spec/defines/server/section_spec.rb
+++ b/spec/defines/server/section_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
 describe 'rsync::server::section' do
-  context 'supported operating systems' do
-    on_supported_os.each do |os, os_facts|
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
       let(:title) { 'test' }
 
       let(:facts) { os_facts }
@@ -11,13 +11,47 @@ describe 'rsync::server::section' do
         'include "::rsync::server"'
       }
 
-      let(:params) {{
-        :path => '/test/dir'
-      }}
+      context 'with default parameters' do
+        let(:params) {{
+          :path => '/test/dir'
+        }}
 
-      context "on #{os}" do
         it { is_expected.to compile.with_all_deps }
         it { is_expected.to create_concat__fragment("rsync_#{title}.section") }
+        it { is_expected.to_not create_file("/etc/rsync/#{title}.rsyncd.secrets") }
+      end
+
+      context 'with user_pass and comment parameters set' do
+        let(:params) {{
+          :path       => '/test/dir',
+          :user_pass  => [ 'user1:user1password', 'user2:user2password', 'skipme'],
+          :comment    => 'section TEST'
+        }}
+
+        it { is_expected.to compile.with_all_deps }
+        it do
+          is_expected.to create_file("/etc/rsync/#{title}.rsyncd.secrets").with(
+            :ensure    => 'file',
+            :owner     => 'root',
+            :group     => 'root',
+            :mode      => '0600',
+            :show_diff => false,
+            :content   => <<-EOM
+user1:user1password
+user2:user2password
+            EOM
+          )
+        end
+      end
+
+      context 'with auth_users parameter set' do
+        let(:params) {{
+          :path       => '/test/dir',
+          :auth_users => [ 'authuser1', 'authuser2'],
+        }}
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to create_file("/etc/rsync/#{title}.rsyncd.secrets").with_content(/^authuser1:/) }
+        it { is_expected.to create_file("/etc/rsync/#{title}.rsyncd.secrets").with_content(/^authuser2:/) }
       end
     end
   end

--- a/templates/secrets.erb
+++ b/templates/secrets.erb
@@ -5,14 +5,13 @@ if @user_pass
 
   Array(@user_pass).each do |pair|
 
-    if @pair.include?(':')
-      t_result.push(@pair)
+    if pair.include?(':')
+      t_result.push(pair)
     end
   end
 else
-  Puppet::Parser::Functions::function('passgen')
   @auth_users.each do |u|
-    t_result.push("#{u}:#{scope.function_passgen([u])}")
+    t_result.push("#{u}:#{scope.call_function('simplib::passgen', [u])}")
   end
 end
 -%>


### PR DESCRIPTION
- Fixed a template bug that prevented catalogue compilation when
  rsync::server::section::user_pass was set
- Use simplib::passgen() in lieu of passgen(), a deprecated simplib
  Puppet 3 function.

SIMP-6110 #comment pupmod-simp-rsync