### PR TITLE
(SIMP-8075) Update Dependencies

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -20,6 +20,7 @@ fixtures:
     selinux_core: https://github.com/puppetlabs/puppetlabs-selinux_core
     simp_firewalld: https://github.com/simp/pupmod-simp-simp_firewalld
     simp_options: https://github.com/simp/pupmod-simp-simp_options
+    simp_firewalld: https://github.com/simp/pupmod-simp-simp_firewalld
     simplib: https://github.com/simp/pupmod-simp-simplib
     simpcat: https://github.com/simp/pupmod-simp-simpcat
     stdlib: https://github.com/simp/puppetlabs-stdlib

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -95,7 +95,6 @@ variables:
 .skip_job_when_commit_message_says_to: &skip_job_when_commit_message_says_to
   if: '$CI_COMMIT_MESSAGE =~ /\n?CI: (SKIP MATRIX|MATRIX LEVEL 0)/'
   when: never
-  if: '$CI_COMMIT_MESSAGE =~ /^CI: (SKIP MATRIX|MATRIX LEVEL 0)/'
 
 .force_run_job_when_commit_message_lvl_1_or_above: &force_run_job_when_commit_mssage_lvl_1_or_above
   if: '$CI_COMMIT_MESSAGE =~ /\n?CI: MATRIX LEVEL [123]/'

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -95,6 +95,7 @@ variables:
 .skip_job_when_commit_message_says_to: &skip_job_when_commit_message_says_to
   if: '$CI_COMMIT_MESSAGE =~ /\n?CI: (SKIP MATRIX|MATRIX LEVEL 0)/'
   when: never
+  if: '$CI_COMMIT_MESSAGE =~ /^CI: (SKIP MATRIX|MATRIX LEVEL 0)/'
 
 .force_run_job_when_commit_message_lvl_1_or_above: &force_run_job_when_commit_mssage_lvl_1_or_above
   if: '$CI_COMMIT_MESSAGE =~ /\n?CI: MATRIX LEVEL [123]/'

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Wed Jul 29 2020 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - 6.4.1-0
+- Update upper bound for vox_selinux to < 4.0.0
+
 * Fri Jan 10 2020 Liz Nemsick <lnemsick.simp@gmail.com> - 6.4.0-0
 - Add EL8 support
 - Update the upper bound of simp-simplib to < 5.0.0

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-rsync",
-  "version": "6.4.0",
+  "version": "6.4.1",
   "author": "SIMP Team",
   "summary": "manage an rsync server, secured by stunnel",
   "license": "Apache-2.0",
@@ -35,7 +35,7 @@
     },
     {
       "name": "simp/vox_selinux",
-      "version_requirement": ">= 1.5.2 < 2.0.0"
+      "version_requirement": ">= 1.5.2 < 4.0.0"
     }
   ],
   "operatingsystem_support": [

--- a/spec/acceptance/suites/default/00_default_spec.rb
+++ b/spec/acceptance/suites/default/00_default_spec.rb
@@ -46,8 +46,9 @@ describe 'rsync class' do
   }
 
   let(:hieradata) {{
-    'simp_options::pki'      => false,
-    'rsync::server::stunnel' => false
+    'iptables::precise_match' => true,
+    'simp_options::pki'       => false,
+    'rsync::server::stunnel'  => false
   }}
 
   hosts.each do |host|

--- a/spec/acceptance/suites/default/10_server_client_spec.rb
+++ b/spec/acceptance/suites/default/10_server_client_spec.rb
@@ -80,6 +80,7 @@ describe 'server and client connectivity' do
         }
 
         let(:hieradata_server1) {{
+          'iptables::precise_match'             => true,
           'simp_options::pki'                   => false,
           'simp_options::firewall'              => true,
           'rsync::server::stunnel'              => false,
@@ -89,6 +90,7 @@ describe 'server and client connectivity' do
         }}
 
         let(:hieradata_server2) {{
+          'iptables::precise_match'             => true,
           'simp_options::pki'                   => false,
           'simp_options::firewall'              => true,
           'rsync::server::stunnel'              => false,
@@ -121,11 +123,12 @@ describe 'server and client connectivity' do
               end
 
               it 'should be idempotent' do
+                # IPTables updates may occur
+                apply_manifest_on(host, manifest, :catch_failures => true)
                 apply_manifest_on(host, manifest, {:catch_changes => true})
               end
             end
           end
-
         end
 
         context 'test a file retrieval' do

--- a/spec/acceptance/suites/default/10_server_client_spec.rb
+++ b/spec/acceptance/suites/default/10_server_client_spec.rb
@@ -123,8 +123,6 @@ describe 'server and client connectivity' do
               end
 
               it 'should be idempotent' do
-                # IPTables updates may occur
-                apply_manifest_on(host, manifest, :catch_failures => true)
                 apply_manifest_on(host, manifest, {:catch_changes => true})
               end
             end

--- a/spec/acceptance/suites/default/20_server_client_stunnel_spec.rb
+++ b/spec/acceptance/suites/default/20_server_client_stunnel_spec.rb
@@ -163,8 +163,6 @@ describe 'server and client stunnel connectivity' do
             end
 
             it 'should be idempotent' do
-              # IPTables changes may occur
-              apply_manifest_on(server1, manifest_server1, :catch_failures => true)
               apply_manifest_on(server1, manifest_server1, :catch_changes => true)
             end
           end

--- a/spec/acceptance/suites/default/20_server_client_stunnel_spec.rb
+++ b/spec/acceptance/suites/default/20_server_client_stunnel_spec.rb
@@ -127,6 +127,7 @@ describe 'server and client stunnel connectivity' do
         }
 
         let(:hieradata_server1) {{
+          'iptables::precise_match'     => true,
           'simp_options::pki'           => true,
           'simp_options::pki::source'   => '/etc/pki/simp-testing/pki',
           'simp_options::firewall'      => true,
@@ -135,11 +136,12 @@ describe 'server and client stunnel connectivity' do
         }}
 
         let(:hieradata_server2) {{
+          'iptables::precise_match'     => true,
           'simp_options::pki'           => true,
           'simp_options::pki::source'   => '/etc/pki/simp-testing/pki',
           'simp_options::firewall'      => true,
           'rsync::server::stunnel'      => true,
-          'rsync::server::global::port'  => 8873,
+          'rsync::server::global::port' => 8873,
           'rsync::server::trusted_nets' => [server1_ip],
         }}
 
@@ -161,6 +163,8 @@ describe 'server and client stunnel connectivity' do
             end
 
             it 'should be idempotent' do
+              # IPTables changes may occur
+              apply_manifest_on(server1, manifest_server1, :catch_failures => true)
               apply_manifest_on(server1, manifest_server1, :catch_changes => true)
             end
           end


### PR DESCRIPTION
- update the upperbound of vox_selinux to < 4.0.0
- update tests to use firewalld for el7 and el8.  Also added
  a loop to create the trusted_net list in the tests.
- NOTE: acceptence are failing because of error in iptables:  it does not recognize change when
  only port is changed.  Error does notoccur when firewalld is used.

SIMP-8075 #comment
SIMP-8320 #close