### PR TITLE
Remove references to archived SIMP modules

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -23,7 +23,6 @@ fixtures:
     stdlib: https://github.com/simp/puppetlabs-stdlib.git
     stunnel: https://github.com/simp/pupmod-simp-stunnel.git
     systemd: https://github.com/simp/puppet-systemd.git
-    tcpwrappers: https://github.com/simp/pupmod-simp-tcpwrappers.git
     vox_selinux:
       repo: https://github.com/simp/pupmod-voxpupuli-selinux.git
       branch: simp-master

--- a/manifests/server/global.pp
+++ b/manifests/server/global.pp
@@ -23,9 +23,6 @@
 #   The networks to allow to connect to this service
 #
 #
-# @param tcpwrappers
-#   Use tcpwrappers to secure the rsync service
-#
 # @author Trevor Vaughan <tvaughan@onyxpoint.com>
 #
 class rsync::server::global (
@@ -35,22 +32,10 @@ class rsync::server::global (
   Simplib::Port                  $port            = 873,
   Simplib::IP                    $address         = '127.0.0.1',
   Simplib::Netlist               $trusted_nets    = simplib::lookup('simp_options::trusted_nets', { default_value => ['127.0.0.1'] }),
-  Boolean                        $tcpwrappers     = simplib::lookup('simp_options::tcpwrappers', { default_value => false })
 ) {
   assert_private()
 
   include '::rsync::server'
-
-  if $tcpwrappers {
-    include '::tcpwrappers'
-
-    $_tcp_wrappers_name = $::rsync::server::stunnel ? {
-      true    => 'rsync_server',
-      default => 'rsync',
-    }
-
-    tcpwrappers::allow { $_tcp_wrappers_name: pattern => $trusted_nets }
-  }
 
   if $facts['os']['selinux']['current_mode'] and $facts['os']['selinux']['current_mode'] != 'disabled' {
     vox_selinux::port { "allow_rsync_port_${port}":

--- a/spec/classes/server/global_spec.rb
+++ b/spec/classes/server/global_spec.rb
@@ -13,19 +13,6 @@ describe 'rsync::server::global' do
 
         it { is_expected.to compile.with_all_deps }
         it { is_expected.to create_concat__fragment('rsync_global').with_content(%r{address = 127.0.0.1}) }
-        it { is_expected.not_to create_tcpwrappers__allow('rsync') }
-
-        context 'with tcpwrappers' do
-          let(:params) do
-            {
-              tcpwrappers: true,
-            }
-          end
-
-          it { is_expected.to compile.with_all_deps }
-          it { is_expected.to create_concat__fragment('rsync_global').with_content(%r{address = 127.0.0.1}) }
-          it { is_expected.to create_tcpwrappers__allow('rsync_server') }
-        end
       end
     end
   end


### PR DESCRIPTION
Remove all references to the following archived modules: chkrootkit, hirs_provisioner, incron, network, rkhunter, simp_bolt, simp_ipa, simp_openldap, simp_pki_service, sudosh, tcpwrappers, tpm, xinetd

This includes removal from metadata.json dependencies, .fixtures.yml, Puppetfiles, manifests, spec tests, hiera data, and acceptance tests as applicable.