### PR TITLE
Cleanup for 8.0.0 release: migrate to 6.x stack and run acceptance under Vagrant

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -26,5 +26,3 @@ fixtures:
     vox_selinux:
       repo: https://github.com/simp/pupmod-voxpupuli-selinux.git
       branch: simp-master
-  symlinks:
-    rsync: "#{source_dir}"

--- a/.github/workflows/pr_tests.yml
+++ b/.github/workflows/pr_tests.yml
@@ -110,7 +110,7 @@ jobs:
           ruby-version: ${{matrix.puppet.ruby_version}}
           bundler-cache: true
       - run: 'command -v rpm || if command -v apt-get; then sudo apt-get update; sudo apt-get install -y rpm; fi ||:'
-      - run: 'bundle exec rake spec'
+      - run: 'bundle exec rake parallel_spec'
         continue-on-error: ${{matrix.puppet.experimental}}
 
   acceptance:

--- a/.github/workflows/pr_tests.yml
+++ b/.github/workflows/pr_tests.yml
@@ -10,9 +10,9 @@
 #
 # https://docs.github.com/en/actions/reference/events-that-trigger-workflows
 #
-
+---
 name: PR Tests
-on:
+'on':
   pull_request:
     types: [opened, reopened, synchronize]
 
@@ -110,46 +110,44 @@ jobs:
           ruby-version: ${{matrix.puppet.ruby_version}}
           bundler-cache: true
       - run: 'command -v rpm || if command -v apt-get; then sudo apt-get update; sudo apt-get install -y rpm; fi ||:'
-      - run: 'bundle exec rake parallel_spec'
+      - run: 'bundle exec rake spec'
         continue-on-error: ${{matrix.puppet.experimental}}
 
-  # Acceptance tests pass locally, but fail out in github, we suspect this is a rootless deployment issue.
-  # We'll need to revisit this in the future.
-  # acceptance:
-  #   runs-on:
-  #     - ubuntu-latest
-  #   strategy:
-  #     matrix:
-  #       node:
-  #         - docker_alma8
-  #         - docker_alma9
-  #         - docker_alma10
-  #         - docker_centos9
-  #         - docker_centos10
-  #         - docker_oel8
-  #         - docker_oel9
-  #         - docker_oel10
-  #         - docker_rhel8
-  #         - docker_rhel9
-  #         - docker_rhel10
-  #         - docker_rocky8
-  #         - docker_rocky9
-  #         - docker_rocky10
-  #     fail-fast: false
-  #   steps:
-  #     - name: checkout repo
-  #       uses: actions/checkout@v4
-  #     - name: setup ruby
-  #       uses: ruby/setup-ruby@v1
-  #       with:
-  #         ruby-version: 3.2
-  #     - name: bundle install
-  #       run: |
-  #         bundle install
-  #     - name: Setup podman
-  #       run: |
-  #         systemctl start --user podman.socket
-  #         echo "DOCKER_HOST=unix:///run/user/$(id -u)/podman/podman.sock" >> "$GITHUB_ENV"
-  #     - name: beaker
-  #       run: |
-  #         bundle exec rake beaker:suites[default,${{ matrix.node }}]
+  acceptance:
+    runs-on:
+      - ubuntu-latest
+    strategy:
+      matrix:
+        node:
+          - docker_alma8
+          - docker_alma9
+          - docker_alma10
+          - docker_centos9
+          - docker_centos10
+          - docker_oel8
+          - docker_oel9
+          - docker_oel10
+          - docker_rhel8
+          - docker_rhel9
+          - docker_rhel10
+          - docker_rocky8
+          - docker_rocky9
+          - docker_rocky10
+      fail-fast: false
+    steps:
+      - name: checkout repo
+        uses: actions/checkout@v6
+      - name: setup ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.4.9
+      - name: bundle install
+        run: |
+          bundle install
+      - name: Setup podman
+        run: |
+          systemctl start --user podman.socket
+          echo "DOCKER_HOST=unix:///run/user/$(id -u)/podman/podman.sock" >> "$GITHUB_ENV"
+      - name: beaker
+        run: |
+          bundle exec rake beaker:suites[default,${{ matrix.node }}]

--- a/.github/workflows/pr_tests.yml
+++ b/.github/workflows/pr_tests.yml
@@ -112,31 +112,19 @@ jobs:
       - run: 'command -v rpm || if command -v apt-get; then sudo apt-get update; sudo apt-get install -y rpm; fi ||:'
       - run: 'bundle exec rake parallel_spec'
         continue-on-error: ${{matrix.puppet.experimental}}
-
   acceptance:
     runs-on:
       - ubuntu-latest
     strategy:
       matrix:
         node:
-          - docker_alma8
-          - docker_alma9
-          - docker_alma10
-          - docker_centos9
-          - docker_centos10
-          - docker_oel8
-          - docker_oel9
-          - docker_oel10
-          - docker_rhel8
-          - docker_rhel9
-          - docker_rhel10
-          - docker_rocky8
-          - docker_rocky9
-          - docker_rocky10
+          - almalinux8
+          - almalinux9
+          - almalinux10
       fail-fast: false
     steps:
       - name: checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: setup ruby
         uses: ruby/setup-ruby@v1
         with:
@@ -144,10 +132,15 @@ jobs:
       - name: bundle install
         run: |
           bundle install
-      - name: Setup podman
+      - name: Setup libvirt for Vagrant
         run: |
-          systemctl start --user podman.socket
-          echo "DOCKER_HOST=unix:///run/user/$(id -u)/podman/podman.sock" >> "$GITHUB_ENV"
+          sudo add-apt-repository ppa:evgeni/vagrant
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends vagrant vagrant-libvirt libvirt-daemon-system libvirt-daemon qemu-system-x86 qemu-utils dnsmasq
+          sudo chmod 666 /var/run/libvirt/libvirt-sock
       - name: beaker
+        env:
+          BEAKER_HYPERVISOR: 'vagrant_libvirt'
+          VAGRANT_DEFAULT_PROVIDER: 'libvirt'
         run: |
           bundle exec rake beaker:suites[default,${{ matrix.node }}]

--- a/.github/workflows/tag_deploy.yml
+++ b/.github/workflows/tag_deploy.yml
@@ -39,7 +39,7 @@ on:
       - '[0-9]+\.[0-9]+\.[0-9]+\-[a-z]+[0-9]+'
 
 env:
-  PUPPET_VERSION: '~> 7'
+  PUPPET_VERSION: '~> 8'
 
 jobs:
   releng-checks:
@@ -55,7 +55,7 @@ jobs:
           clean: true
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.7.8
+          ruby-version: 3.2.11
           bundler-cache: true
       - run: bundle exec rake pkg:check_version
       - run: bundle exec rake pkg:compare_latest_tag
@@ -180,7 +180,7 @@ jobs:
           clean: true
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.7.8
+          ruby-version: 3.2.11
           bundler-cache: true
       - name: Build Puppet module (PDK)
         run: bundle exec pdk build --force

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -117,7 +117,7 @@
 * Wed Mar 29 2017 Trevor Vaughan <tvaughan@onyxpoint.com> - 6.0.2-0
 - Ensure that rsync password files are not echoed to the Puppet log
 
-* Thu Mar 17 2017 Liz Nemsick <lnemsick.simp@gmail.com> - 6.0.1-0
+* Fri Mar 17 2017 Liz Nemsick <lnemsick.simp@gmail.com> - 6.0.1-0
 - Remove OBE 'pe' requirement from metadata.json
 - Update puppet version in .travis.yaml
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,7 @@
 - Remove unmaintained Compliance Engine data
 - Drop support for end-of-life platforms (Amazon Linux 2, CentOS 8)
 - Drop Puppet 7 support; require openvox >= 8 < 9
+- Point `issues_url` at GitHub Issues; allow newer simp module dependencies (rsyslog 9.x, simplib 5.x, stunnel 8.x).
 
 * Wed Aug 27 2025 Steven Pritchard <steve@sicura.us> - 7.0.1
 - Cleanup for rubocop

--- a/Gemfile
+++ b/Gemfile
@@ -13,10 +13,10 @@ gem_sources.each { |gem_source| source gem_source }
 group :syntax do
   gem 'metadata-json-lint'
   gem 'puppet-lint-trailing_comma-check', require: false
-  gem 'rubocop', '~> 1.88.0'
+  gem 'rubocop', '~> 1.85'
   gem 'rubocop-performance', '~> 1.26.0'
   gem 'rubocop-rake', '~> 0.7.0'
-  gem 'rubocop-rspec', '~> 3.10.0'
+  gem 'rubocop-rspec', '~> 3.9'
 end
 
 group :test do
@@ -30,13 +30,12 @@ group :test do
   ['openvox', 'puppet'].each do |gem_name|
     gem gem_name, binding.local_variable_get("#{gem_name}_version".to_sym)
   end
-  gem 'puppetlabs_spec_helper', '~> 8.0.0'
   gem 'puppet-strings'
   gem 'rake'
   gem 'rspec'
   gem 'rspec-puppet'
   # renovate: datasource=rubygems versioning=ruby
-  gem 'simp-rake-helpers', ENV.fetch('SIMP_RAKE_HELPERS_VERSION', '~> 5.25.0')
+  gem 'simp-rake-helpers', ENV.fetch('SIMP_RAKE_HELPERS_VERSION', '~> 6.0')
   # renovate: datasource=rubygems versioning=ruby
   gem 'simp-rspec-puppet-facts', ENV.fetch('SIMP_RSPEC_PUPPET_FACTS_VERSION', '~> 4.0.0')
 end
@@ -53,7 +52,7 @@ group :system_tests do
   gem 'beaker_puppet_helpers'
   gem 'beaker-rspec'
   # renovate: datasource=rubygems versioning=ruby
-  gem 'simp-beaker-helpers', ENV.fetch('SIMP_BEAKER_HELPERS_VERSION', '~> 2.0.0')
+  gem 'simp-beaker-helpers', ENV.fetch('SIMP_BEAKER_HELPERS_VERSION', '~> 3.1')
 end
 
 # Evaluate extra gemfiles if they exist

--- a/manifests/retrieve.pp
+++ b/manifests/retrieve.pp
@@ -119,7 +119,7 @@ define rsync::retrieve (
   Optional[Catalogentry]                      $rnotify          = undef,
   Optional[Catalogentry]                      $rsubscribe       = undef
 ) {
-  include '::rsync'
+  include 'rsync'
 
   if $pass {
     $_pass = $pass

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -51,8 +51,8 @@ class rsync::server (
   String           $package_ensure     = simplib::lookup('simp_options::package_ensure', { 'default_value' => 'installed' }),
   String           $package            # module data
 ) {
-  include '::rsync'
-  include '::rsync::server::global'
+  include 'rsync'
+  include 'rsync::server::global'
 
   # ensure_resource instead of package resource, because for some OS versions,
   # the client package managed by the rsync class also contains the rsync
@@ -65,10 +65,10 @@ class rsync::server (
   }
 
   if $stunnel {
-    include '::stunnel'
+    include 'stunnel'
 
     stunnel::connection { 'rsync_server':
-      connect      => [$::rsync::server::global::port],
+      connect      => [$rsync::server::global::port],
       accept       => "${listen_address}:${stunnel_port}",
       client       => false,
       trusted_nets => $trusted_nets
@@ -78,7 +78,7 @@ class rsync::server (
       iptables::listen::tcp_stateful { 'allow_rsync_server':
         order        => 11,
         trusted_nets => $trusted_nets,
-        dports       => [$::rsync::server::global::port],
+        dports       => [$rsync::server::global::port],
       }
     }
   }
@@ -127,7 +127,7 @@ class rsync::server (
   Concat['/etc/rsyncd.conf'] ~> Service['rsyncd']
 
   if $drop_rsyslog_noise {
-    include '::rsyslog'
+    include 'rsyslog'
 
     rsyslog::rule::drop { '00_rsyncd':
       rule => '$programname == \'rsyncd\' and not ($msg contains \'rsync on\' or $msg contains \'SIG\' or $msg contains \'listening\')'

--- a/manifests/server/global.pp
+++ b/manifests/server/global.pp
@@ -39,12 +39,12 @@ class rsync::server::global (
 ) {
   assert_private()
 
-  include '::rsync::server'
+  include 'rsync::server'
 
   if $tcpwrappers {
-    include '::tcpwrappers'
+    include 'tcpwrappers'
 
-    $_tcp_wrappers_name = $::rsync::server::stunnel ? {
+    $_tcp_wrappers_name = $rsync::server::stunnel ? {
       true    => 'rsync_server',
       default => 'rsync',
     }

--- a/manifests/server/section.pp
+++ b/manifests/server/section.pp
@@ -123,7 +123,7 @@ define rsync::server::section (
   Variant[Enum['*'], Simplib::Netlist] $hosts_allow        = simplib::lookup('simp_options::trusted_nets', { 'default_value' => ['127.0.0.1'] }),
   Variant[Enum['*'], Simplib::Netlist] $hosts_deny         = '*'
 ) {
-  include '::rsync::server'
+  include 'rsync::server'
 
   concat::fragment { "rsync_${name}.section":
     order   => 10,

--- a/metadata.json
+++ b/metadata.json
@@ -6,7 +6,7 @@
   "license": "Apache-2.0",
   "source": "https://github.com/simp/pupmod-simp-rsync",
   "project_page": "https://github.com/simp/pupmod-simp-rsync",
-  "issues_url": "https://simp-project.atlassian.net",
+  "issues_url": "https://github.com/simp/pupmod-simp-rsync/issues",
   "tags": [
     "simp",
     "rsync",
@@ -23,15 +23,15 @@
     },
     {
       "name": "simp/rsyslog",
-      "version_requirement": ">= 7.6.0 < 9.0.0"
+      "version_requirement": ">= 7.6.0 < 10.0.0"
     },
     {
       "name": "simp/simplib",
-      "version_requirement": ">= 4.9.0 < 5.0.0"
+      "version_requirement": ">= 4.9.0 < 6.0.0"
     },
     {
       "name": "simp/stunnel",
-      "version_requirement": ">= 6.6.0 < 7.0.0"
+      "version_requirement": ">= 6.6.0 < 9.0.0"
     },
     {
       "name": "simp/vox_selinux",

--- a/spec/acceptance/helpers/utils.rb
+++ b/spec/acceptance/helpers/utils.rb
@@ -1,3 +1,6 @@
+# The nested Acceptance::Helpers::Utils namespace requires forward
+# declaration of its parent modules in this single helper file.
+# rubocop:disable Style/OneClassPerFile
 module Acceptance; end
 module Acceptance::Helpers; end
 
@@ -21,3 +24,4 @@ module Acceptance::Helpers::Utils
     unique_pairs.to_a
   end
 end
+# rubocop:enable Style/OneClassPerFile

--- a/spec/acceptance/nodesets/almalinux10.yml
+++ b/spec/acceptance/nodesets/almalinux10.yml
@@ -1,0 +1,19 @@
+---
+HOSTS:
+  almalinux10:
+    roles:
+    - default
+    - master
+    - server
+    - el10
+    platform: el-10-x86_64
+    box: almalinux/10
+    hypervisor: "<%= ENV.fetch('BEAKER_HYPERVISOR', 'vagrant') %>"
+    vagrant_memsize: 2048
+    vagrant_cpus: 2
+    family: almalinux-cloud/almalinux-10
+    gce_machine_type: n1-standard-2
+CONFIG:
+  log_level: verbose
+  type: aio
+  puppet_collection: "<%= ENV.fetch('BEAKER_PUPPET_COLLECTION', 'openvox8') %>"

--- a/spec/acceptance/nodesets/almalinux8.yml
+++ b/spec/acceptance/nodesets/almalinux8.yml
@@ -1,0 +1,19 @@
+---
+HOSTS:
+  almalinux8:
+    roles:
+    - default
+    - master
+    - server
+    - el8
+    platform: el-8-x86_64
+    box: almalinux/8
+    hypervisor: "<%= ENV.fetch('BEAKER_HYPERVISOR', 'vagrant') %>"
+    vagrant_memsize: 2048
+    vagrant_cpus: 2
+    family: almalinux-cloud/almalinux-8
+    gce_machine_type: n1-standard-2
+CONFIG:
+  log_level: verbose
+  type: aio
+  puppet_collection: "<%= ENV.fetch('BEAKER_PUPPET_COLLECTION', 'openvox8') %>"

--- a/spec/acceptance/nodesets/almalinux9.yml
+++ b/spec/acceptance/nodesets/almalinux9.yml
@@ -1,0 +1,19 @@
+---
+HOSTS:
+  almalinux9:
+    roles:
+    - default
+    - master
+    - server
+    - el9
+    platform: el-9-x86_64
+    box: almalinux/9
+    hypervisor: "<%= ENV.fetch('BEAKER_HYPERVISOR', 'vagrant') %>"
+    vagrant_memsize: 2048
+    vagrant_cpus: 2
+    family: almalinux-cloud/almalinux-9
+    gce_machine_type: n1-standard-2
+CONFIG:
+  log_level: verbose
+  type: aio
+  puppet_collection: "<%= ENV.fetch('BEAKER_PUPPET_COLLECTION', 'openvox8') %>"

--- a/spec/acceptance/nodesets/centos10.yml
+++ b/spec/acceptance/nodesets/centos10.yml
@@ -1,0 +1,19 @@
+---
+HOSTS:
+  centos10:
+    roles:
+    - default
+    - master
+    - server
+    - el10
+    platform: el-10-x86_64
+    box: generic/centos10s
+    hypervisor: "<%= ENV.fetch('BEAKER_HYPERVISOR', 'vagrant') %>"
+    vagrant_memsize: 2048
+    vagrant_cpus: 2
+    family: centos-cloud/centos-stream-10
+    gce_machine_type: n1-standard-2
+CONFIG:
+  log_level: verbose
+  type: aio
+  puppet_collection: "<%= ENV.fetch('BEAKER_PUPPET_COLLECTION', 'openvox8') %>"

--- a/spec/acceptance/nodesets/centos9.yml
+++ b/spec/acceptance/nodesets/centos9.yml
@@ -1,0 +1,19 @@
+---
+HOSTS:
+  centos9:
+    roles:
+    - default
+    - master
+    - server
+    - el9
+    platform: el-9-x86_64
+    box: generic/centos9s
+    hypervisor: "<%= ENV.fetch('BEAKER_HYPERVISOR', 'vagrant') %>"
+    vagrant_memsize: 2048
+    vagrant_cpus: 2
+    family: centos-cloud/centos-stream-9
+    gce_machine_type: n1-standard-2
+CONFIG:
+  log_level: verbose
+  type: aio
+  puppet_collection: "<%= ENV.fetch('BEAKER_PUPPET_COLLECTION', 'openvox8') %>"

--- a/spec/acceptance/nodesets/oel10.yml
+++ b/spec/acceptance/nodesets/oel10.yml
@@ -1,0 +1,17 @@
+---
+HOSTS:
+  oel10:
+    roles:
+    - default
+    - master
+    - server
+    - el10
+    platform: el-10-x86_64
+    box: generic/oracle10
+    hypervisor: "<%= ENV.fetch('BEAKER_HYPERVISOR', 'vagrant') %>"
+    vagrant_memsize: 2048
+    vagrant_cpus: 2
+CONFIG:
+  log_level: verbose
+  type: aio
+  puppet_collection: "<%= ENV.fetch('BEAKER_PUPPET_COLLECTION', 'openvox8') %>"

--- a/spec/acceptance/nodesets/oel8.yml
+++ b/spec/acceptance/nodesets/oel8.yml
@@ -1,0 +1,17 @@
+---
+HOSTS:
+  oel8:
+    roles:
+    - default
+    - master
+    - server
+    - el8
+    platform: el-8-x86_64
+    box: generic/oracle8
+    hypervisor: "<%= ENV.fetch('BEAKER_HYPERVISOR', 'vagrant') %>"
+    vagrant_memsize: 2048
+    vagrant_cpus: 2
+CONFIG:
+  log_level: verbose
+  type: aio
+  puppet_collection: "<%= ENV.fetch('BEAKER_PUPPET_COLLECTION', 'openvox8') %>"

--- a/spec/acceptance/nodesets/oel9.yml
+++ b/spec/acceptance/nodesets/oel9.yml
@@ -1,0 +1,17 @@
+---
+HOSTS:
+  oel9:
+    roles:
+    - default
+    - master
+    - server
+    - el9
+    platform: el-9-x86_64
+    box: generic/oracle9
+    hypervisor: "<%= ENV.fetch('BEAKER_HYPERVISOR', 'vagrant') %>"
+    vagrant_memsize: 2048
+    vagrant_cpus: 2
+CONFIG:
+  log_level: verbose
+  type: aio
+  puppet_collection: "<%= ENV.fetch('BEAKER_PUPPET_COLLECTION', 'openvox8') %>"

--- a/spec/acceptance/nodesets/rhel10.yml
+++ b/spec/acceptance/nodesets/rhel10.yml
@@ -1,0 +1,19 @@
+---
+HOSTS:
+  rhel10:
+    roles:
+    - default
+    - master
+    - server
+    - el10
+    platform: el-10-x86_64
+    box: generic/rhel10
+    hypervisor: "<%= ENV.fetch('BEAKER_HYPERVISOR', 'vagrant') %>"
+    vagrant_memsize: 2048
+    vagrant_cpus: 2
+    family: rhel-cloud/rhel-10
+    gce_machine_type: n1-standard-2
+CONFIG:
+  log_level: verbose
+  type: aio
+  puppet_collection: "<%= ENV.fetch('BEAKER_PUPPET_COLLECTION', 'openvox8') %>"

--- a/spec/acceptance/nodesets/rhel8.yml
+++ b/spec/acceptance/nodesets/rhel8.yml
@@ -1,0 +1,19 @@
+---
+HOSTS:
+  rhel8:
+    roles:
+    - default
+    - master
+    - server
+    - el8
+    platform: el-8-x86_64
+    box: generic/rhel8
+    hypervisor: "<%= ENV.fetch('BEAKER_HYPERVISOR', 'vagrant') %>"
+    vagrant_memsize: 2048
+    vagrant_cpus: 2
+    family: rhel-cloud/rhel-8
+    gce_machine_type: n1-standard-2
+CONFIG:
+  log_level: verbose
+  type: aio
+  puppet_collection: "<%= ENV.fetch('BEAKER_PUPPET_COLLECTION', 'openvox8') %>"

--- a/spec/acceptance/nodesets/rhel9.yml
+++ b/spec/acceptance/nodesets/rhel9.yml
@@ -1,0 +1,19 @@
+---
+HOSTS:
+  rhel9:
+    roles:
+    - default
+    - master
+    - server
+    - el9
+    platform: el-9-x86_64
+    box: generic/rhel9
+    hypervisor: "<%= ENV.fetch('BEAKER_HYPERVISOR', 'vagrant') %>"
+    vagrant_memsize: 2048
+    vagrant_cpus: 2
+    family: rhel-cloud/rhel-9
+    gce_machine_type: n1-standard-2
+CONFIG:
+  log_level: verbose
+  type: aio
+  puppet_collection: "<%= ENV.fetch('BEAKER_PUPPET_COLLECTION', 'openvox8') %>"

--- a/spec/acceptance/nodesets/rocky10.yml
+++ b/spec/acceptance/nodesets/rocky10.yml
@@ -1,0 +1,19 @@
+---
+HOSTS:
+  rocky10:
+    roles:
+    - default
+    - master
+    - server
+    - el10
+    platform: el-10-x86_64
+    box: rockylinux/10
+    hypervisor: "<%= ENV.fetch('BEAKER_HYPERVISOR', 'vagrant') %>"
+    vagrant_memsize: 2048
+    vagrant_cpus: 2
+    family: rocky-linux-cloud/rocky-linux-10
+    gce_machine_type: n1-standard-2
+CONFIG:
+  log_level: verbose
+  type: aio
+  puppet_collection: "<%= ENV.fetch('BEAKER_PUPPET_COLLECTION', 'openvox8') %>"

--- a/spec/acceptance/nodesets/rocky8.yml
+++ b/spec/acceptance/nodesets/rocky8.yml
@@ -1,0 +1,19 @@
+---
+HOSTS:
+  rocky8:
+    roles:
+    - default
+    - master
+    - server
+    - el8
+    platform: el-8-x86_64
+    box: rockylinux/8
+    hypervisor: "<%= ENV.fetch('BEAKER_HYPERVISOR', 'vagrant') %>"
+    vagrant_memsize: 2048
+    vagrant_cpus: 2
+    family: rocky-linux-cloud/rocky-linux-8
+    gce_machine_type: n1-standard-2
+CONFIG:
+  log_level: verbose
+  type: aio
+  puppet_collection: "<%= ENV.fetch('BEAKER_PUPPET_COLLECTION', 'openvox8') %>"

--- a/spec/acceptance/nodesets/rocky9.yml
+++ b/spec/acceptance/nodesets/rocky9.yml
@@ -1,0 +1,19 @@
+---
+HOSTS:
+  rocky9:
+    roles:
+    - default
+    - master
+    - server
+    - el9
+    platform: el-9-x86_64
+    box: rockylinux/9
+    hypervisor: "<%= ENV.fetch('BEAKER_HYPERVISOR', 'vagrant') %>"
+    vagrant_memsize: 2048
+    vagrant_cpus: 2
+    family: rocky-linux-cloud/rocky-linux-9
+    gce_machine_type: n1-standard-2
+CONFIG:
+  log_level: verbose
+  type: aio
+  puppet_collection: "<%= ENV.fetch('BEAKER_PUPPET_COLLECTION', 'openvox8') %>"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,7 +8,7 @@
 # The next baseline sync will overwrite any local changes made to this file.
 # ------------------------------------------------------------------------------
 
-require 'puppetlabs_spec_helper/module_spec_helper'
+require 'voxpupuli/test/spec_helper'
 require 'rspec-puppet'
 require 'simp/rspec-puppet-facts'
 include Simp::RspecPuppetFacts


### PR DESCRIPTION
## Summary

The 8.0.0 metadata cleanup, plus the test-stack migration and a correction to how acceptance is run.

### Metadata cleanup
- `requirements` `puppet` → `openvox` (>= 8 < 9); `issues_url` → GitHub Issues
- Drop EOL OS support (CentOS 8, EL7); add EL10; allow newer SIMP module deps

### Test stack migration
- `simp-rake-helpers ~> 6.0` / `simp-beaker-helpers ~> 3.1`; voxpupuli-test/puppet_fixtures; drop `puppetlabs_spec_helper`; `rubocop ~> 1.85`
- Disable `Style/OneClassPerFile` for the acceptance `Utils` helper (its nested namespace forward-declares parent modules in one file)

### Acceptance: docker → Vagrant
The docker matrix ran under **rootless podman** in CI, where the `rsyslog` systemd service — pulled in by `rsync::server` via `drop_rsyslog_noise` — cannot start (`Systemd start for rsyslog failed!`), failing every OS. The migration alone was insufficient (it passes under real Docker but not rootless podman). Point the acceptance matrix at the Vagrant nodesets (`almalinux8/9/10`), matching the other modules that need a real systemd (e.g. pupmod-simp-simp_rsyslog).

> `pr_tests.yml` carries the puppetsync marker but the acceptance matrix is per-module in practice; kept structurally identical to the ssh/selinux/pam vagrant jobs for a follow-up puppetsync-template fix.

### Validation (local Vagrant)
almalinux8/9/10 each: 5 examples, 0 failures, 2 pending · unit: 477 examples, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)
